### PR TITLE
added SSH_AUTH_SOCK env var, known_hosts symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docker/data/sql
 docker/data/elasticsearch
+docker/data/known_hosts
 docker/apache-php/Dockerfile
 docker/data/.bash_history
 docker-env

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -45,6 +45,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 COPY php.ini /usr/local/etc/php/
 COPY bashrc.dist /var/www/.bashrc
 RUN ln -s /var/www/html/docker/data/.bash_history /var/www/.bash_history
+RUN mkdir /var/www/.ssh
+RUN ln -s /var/www/html/docker/data/known_hosts /var/www/.ssh/known_hosts
 COPY apache2.conf /etc/apache2/apache2.conf
 
 RUN usermod -u $USER_ID www-data -s /bin/bash

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,11 +8,15 @@ sf_web:
         - 9001:9000 #xdebug
     volumes:
         - "../:/var/www/html"
+        - $SSH_AUTH_SOCK:$SSH_AUTH_SOCK
+        - "~/.composer:/var/www/.composer"
     links:
         - db
         - elasticsearch
         - mailcatcher
         - blackfire
+    environment:
+        - SSH_AUTH_SOCK=$SSH_AUTH_SOCK
     env_file:
         - docker-env
 
@@ -21,15 +25,15 @@ db:
     image: mysql:latest
     container_name: "sf_db"
     ports:
-    - 3306
+        - 3306
     environment:
         MYSQL_DATABASE: sf3
         MYSQL_USER: sf3
         MYSQL_PASSWORD: sf3
         MYSQL_ROOT_PASSWORD: root
     volumes:
-    - ./data/sql:/var/lib/mysql
-    - ./mysql/my.cnf:/etc/mysql/conf.d/z_my.cnf
+        - ./data/sql:/var/lib/mysql
+        - ./mysql/my.cnf:/etc/mysql/conf.d/z_my.cnf
 
 
 #phpmyadmin


### PR DESCRIPTION
- added SSH_AUTH_SOCK env var to enable access to private repos  
  somebody on OSX please test this with dlite and docker-machine, works on linux
- added symlink for known_hosts to container
- added .composer as volume to share composer cache
