### PR TITLE
Set command sf to absolute path

### DIFF
--- a/docker/apache-php/bashrc.dist
+++ b/docker/apache-php/bashrc.dist
@@ -59,7 +59,7 @@ alias rm='rm -i'
 alias mv='mv -iv'
 alias grep='grep --color=auto -in'
 alias ll="ls -ahl"
-alias sf="php bin/console"
+alias sf="php /var/www/html/bin/console"
 alias sfcc="sf cache:clear"
 alias c="clear"
 alias db="mysql -hdb -uroot -proot"


### PR DESCRIPTION
This enables the use of the command sf from all folders
