### PR TITLE
smaller footprint & changed user management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ before_script:
     - sh ./docker.sh -d
 
 script:
-    - docker exec -it sf_web composer require phpunit/phpunit
-    - docker exec -it sf_web vendor/phpunit/phpunit/phpunit
+    - docker exec -u user -it sf_web composer require phpunit/phpunit
+    - docker exec -u user -it sf_web vendor/phpunit/phpunit/phpunit
     - docker-compose stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_script:
     - sh ./docker.sh -d
 
 script:
-    - docker exec -u user -it sf_web composer require phpunit/phpunit
-    - docker exec -u user -it sf_web vendor/phpunit/phpunit/phpunit
+    - docker exec -u user -i sf_web composer require phpunit/phpunit
+    - docker exec -u user -i sf_web vendor/phpunit/phpunit/phpunit
     - docker-compose stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ before_script:
     - sh ./docker.sh -d
 
 script:
-    - docker exec -it -u www-data sf_web composer require phpunit/phpunit
-    - docker exec -it -u www-data sf_web vendor/phpunit/phpunit/phpunit
+    - docker exec -it sf_web composer require phpunit/phpunit
+    - docker exec -it sf_web vendor/phpunit/phpunit/phpunit
     - docker-compose stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 
 language: php
+    - '7.0'
 
 services:
     - docker

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 ## docker-sf3 - advanced LAMP setup for symfony3 development
 
-[![Travis](https://img.shields.io/travis/nerdpress-org/docker-sf3.svg?style=flat-square)](https://travis-ci.org/nerdpress-org/docker-sf3)
 [![SensioLabs Insight](https://img.shields.io/sensiolabs/i/f1433af6-bcd5-4c76-832e-4b1b05df1577.svg?maxAge=2592000&style=flat-square)](https://insight.sensiolabs.com/projects/f1433af6-bcd5-4c76-832e-4b1b05df1577)
 
 permission-hassle free <sup>:tm:</sup> [» More](/Resources/doc/permissions.md)

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -36,11 +36,11 @@ RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
     && rm -rf /tmp/* /var/tmp/* 
 
 
+RUN chmod -R go+rwx /var/www
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer global require hirak/prestissimo \
     && rm -rf /tmp/* /var/tmp/* 
 
-RUN chmod go+rwx /var/www
 COPY php.ini /usr/local/etc/php/
 COPY bashrc.dist /var/www/.bashrc
 COPY apache2.conf /etc/apache2/apache2.conf

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -40,7 +40,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
     && composer global require hirak/prestissimo \
     && rm -rf /tmp/* /var/tmp/* 
 
-
+RUN chmod go+rwx /var/www
 COPY php.ini /usr/local/etc/php/
 COPY bashrc.dist /var/www/.bashrc
 COPY apache2.conf /etc/apache2/apache2.conf

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -36,7 +36,7 @@ RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
     && rm -rf /tmp/* /var/tmp/* 
 
 
-RUN chmod -R go+rwx /var/www
+RUN chmod -R go+rwxs /var/www
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer global require hirak/prestissimo \
     && rm -rf /tmp/* /var/tmp/* 

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -1,7 +1,7 @@
 FROM php:7-apache
 
 RUN a2enmod rewrite
-RUN chmod -R ug+rwxs /var/www
+RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
 RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjpeg62-turbo libpng12-0 libfreetype6" \
     && apt-get update && apt-get install -y --no-install-recommends $RUNTIME_PKGS \
@@ -10,7 +10,6 @@ RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjp
       
 ADD docker-php-pecl-install /usr/local/bin/
 RUN chmod u+x /usr/local/bin/docker-php-pecl-install
-
 
 RUN BUILD_PKGS="zlib1g-dev libicu-dev g++ libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev make" \
     && apt-get update && apt-get install -y --no-install-recommends $BUILD_PKGS \
@@ -41,9 +40,13 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
     && rm -rf /tmp/* /var/tmp/* 
 
 COPY php.ini /usr/local/etc/php/
-COPY bashrc.dist /var/www/.bashrc
 COPY apache2.conf /etc/apache2/apache2.conf
 
-RUN useradd --shell /bin/bash --uid $USER_ID --non-unique --gid www-data --base-dir /var/www -m user
+COPY bashrc.dist /var/www/.bashrc
+
+RUN useradd --shell /bin/bash --uid $USER_ID --non-unique --gid www-data --home /var/www -m user
+RUN chmod -R g+rwx /var/www
+RUN setfacl -R -dm u::rwx,g::rwx,o::r /var/www
+RUN umask 0007
 
 WORKDIR /var/www/html

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -1,16 +1,22 @@
 FROM php:7-apache
 
+#Enable necessary Apache modules
 RUN a2enmod rewrite
+
+#Change your timezone below. Full list of timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
-RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjpeg62-turbo libpng12-0 libfreetype6" \
+#Append software required during runtime here.
+RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu57 libjpeg62-turbo libpng12-0 libfreetype6" \
     && apt-get update && apt-get install -y --no-install-recommends $RUNTIME_PKGS \
     && apt-get autoremove -y && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
-      
+
+#PECL    
 ADD docker-php-pecl-install /usr/local/bin/
 RUN chmod u+x /usr/local/bin/docker-php-pecl-install
 
+#Append software required during build here.
 RUN BUILD_PKGS="zlib1g-dev libicu-dev g++ libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev make" \
     && apt-get update && apt-get install -y --no-install-recommends $BUILD_PKGS \
     && docker-php-ext-install -j$(nproc) iconv mcrypt mbstring exif zip opcache pdo_mysql pcntl \
@@ -23,11 +29,13 @@ RUN BUILD_PKGS="zlib1g-dev libicu-dev g++ libfreetype6-dev libjpeg62-turbo-dev l
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
+#Configure xdebug.
 RUN sed -i '1 a xdebug.remote_autostart=true' /usr/local/etc/php/conf.d/docker-php-pecl-xdebug.ini
 RUN sed -i '1 a xdebug.remote_connect_back=1 ' /usr/local/etc/php/conf.d/docker-php-pecl-xdebug.ini
 RUN sed -i '1 a xdebug.remote_enable=1' /usr/local/etc/php/conf.d/docker-php-pecl-xdebug.ini
 RUN sed -i '1 a xdebug.max_nesting_level = 1200' /usr/local/etc/php/conf.d/docker-php-pecl-xdebug.ini
 
+#Install blackfire.
 RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/${VERSION} \
     && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
@@ -35,18 +43,28 @@ RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
     && echo "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707" > /usr/local/etc/php/conf.d/blackfire.ini \
     && rm -rf /tmp/* /var/tmp/* 
 
+#Install composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer global require hirak/prestissimo \
     && rm -rf /tmp/* /var/tmp/* 
 
+#Populate Environment
 COPY php.ini /usr/local/etc/php/
 COPY apache2.conf /etc/apache2/apache2.conf
-
 COPY bashrc.dist /var/www/.bashrc
 
+#Appears like this section makes no sense with Docker (default) AUFS storage driver.
+#Set ACL
+#RUN setfacl -R -m u::rwx,g:www-data:rwx,o::r /var/www
+#Preserver ACL for new files.
+#RUN setfacl -R -dm u::rwx,g:www-data:rwx,o::r /var/www
+
+#Create Developer "user"" based on  Host UID (from docker.sh) and add UID to the www-data group
 RUN useradd --shell /bin/bash --uid $USER_ID --non-unique --gid www-data --home /var/www -m user
+
+#Fix permissions and umask
+RUN chgrp -R www-data /var/www
 RUN chmod -R g+rwx /var/www
-RUN setfacl -R -dm u::rwx,g::rwx,o::r /var/www
 RUN umask 0007
 
 WORKDIR /var/www/html

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -36,10 +36,8 @@ RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
     && echo "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707" > /usr/local/etc/php/conf.d/blackfire.ini \
     && rm -rf /tmp/* /var/tmp/* 
 
-RUN pushd /tmp \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer global require hirak/prestissimo \
-    && popd \
     && rm -rf /tmp/* /var/tmp/* 
 
 COPY php.ini /usr/local/etc/php/

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -1,7 +1,7 @@
 FROM php:7-apache
 
 RUN a2enmod rewrite
-RUN chmod -R go+rwxs /var/www
+RUN chmod -R UG+rwxs /var/www
 
 RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjpeg62-turbo libpng12-0 libfreetype6" \
     && apt-get update && apt-get install -y --no-install-recommends $RUNTIME_PKGS \

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -7,7 +7,7 @@ RUN a2enmod rewrite
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
 #Append software required during runtime here.
-RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu57 libjpeg62-turbo libpng12-0 libfreetype6" \
+RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjpeg62-turbo libpng12-0 libfreetype6" \
     && apt-get update && apt-get install -y --no-install-recommends $RUNTIME_PKGS \
     && apt-get autoremove -y && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -1,7 +1,7 @@
 FROM php:7-apache
 
 RUN a2enmod rewrite
-RUN chmod -R UG+rwxs /var/www
+RUN chmod -R ug+rwxs /var/www
 
 RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjpeg62-turbo libpng12-0 libfreetype6" \
     && apt-get update && apt-get install -y --no-install-recommends $RUNTIME_PKGS \

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -1,6 +1,7 @@
 FROM php:7-apache
 
 RUN a2enmod rewrite
+RUN chmod -R go+rwxs /var/www
 
 RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjpeg62-turbo libpng12-0 libfreetype6" \
     && apt-get update && apt-get install -y --no-install-recommends $RUNTIME_PKGS \
@@ -35,10 +36,10 @@ RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
     && echo "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707" > /usr/local/etc/php/conf.d/blackfire.ini \
     && rm -rf /tmp/* /var/tmp/* 
 
-
-RUN chmod -R go+rwxs /var/www
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN pushd /tmp \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer global require hirak/prestissimo \
+    && popd \
     && rm -rf /tmp/* /var/tmp/* 
 
 COPY php.ini /usr/local/etc/php/

--- a/docker/apache-php/Dockerfile.dist
+++ b/docker/apache-php/Dockerfile.dist
@@ -2,31 +2,26 @@ FROM php:7-apache
 
 RUN a2enmod rewrite
 
-RUN apt-get update && apt-get install -y -qq \
-        vim \
-        zlib1g-dev \
-        libicu-dev \
-        git \
-        zip \
-        g++ \
-        mysql-client \
-        htop \
-        openssh-client \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libmcrypt-dev \
-        libpng12-dev \
-        make
+RUN RUNTIME_PKGS="vim git zip mcrypt mysql-client htop ssh-client libicu52 libjpeg62-turbo libpng12-0 libfreetype6" \
+    && apt-get update && apt-get install -y --no-install-recommends $RUNTIME_PKGS \
+    && apt-get autoremove -y && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+      
+ADD docker-php-pecl-install /usr/local/bin/
+RUN chmod u+x /usr/local/bin/docker-php-pecl-install
 
-RUN docker-php-ext-install -j$(nproc) iconv mcrypt mbstring exif zip opcache pdo_mysql pcntl \
+
+RUN BUILD_PKGS="zlib1g-dev libicu-dev g++ libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev make" \
+    && apt-get update && apt-get install -y --no-install-recommends $BUILD_PKGS \
+    && docker-php-ext-install -j$(nproc) iconv mcrypt mbstring exif zip opcache pdo_mysql pcntl \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-configure intl \
-    && docker-php-ext-install intl
-
-ADD docker-php-pecl-install /usr/local/bin/
-RUN chmod u+x /usr/local/bin/docker-php-pecl-install
-RUN docker-php-pecl-install xdebug
+    && docker-php-ext-install intl \
+    && docker-php-pecl-install xdebug \
+    && apt-get autoremove -y $BUILD_PKGS \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
 RUN sed -i '1 a xdebug.remote_autostart=true' /usr/local/etc/php/conf.d/docker-php-pecl-xdebug.ini
 RUN sed -i '1 a xdebug.remote_connect_back=1 ' /usr/local/etc/php/conf.d/docker-php-pecl-xdebug.ini
@@ -37,16 +32,19 @@ RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/${VERSION} \
     && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
     && mv /tmp/blackfire-*.so `php -r "echo ini_get('extension_dir');"`/blackfire.so \
-    && echo "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707" > /usr/local/etc/php/conf.d/blackfire.ini
+    && echo "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707" > /usr/local/etc/php/conf.d/blackfire.ini \
+    && rm -rf /tmp/* /var/tmp/* 
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer&& \
-         composer global require hirak/prestissimo
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer global require hirak/prestissimo \
+    && rm -rf /tmp/* /var/tmp/* 
+
 
 COPY php.ini /usr/local/etc/php/
 COPY bashrc.dist /var/www/.bashrc
-RUN ln -s /var/www/html/docker/data/.bash_history /var/www/.bash_history
 COPY apache2.conf /etc/apache2/apache2.conf
 
-RUN usermod -u $USER_ID www-data -s /bin/bash
+RUN useradd --shell /bin/bash --uid $USER_ID --non-unique --gid www-data --base-dir /var/www -m user
 
 WORKDIR /var/www/html

--- a/docker/apache-php/bashrc.dist
+++ b/docker/apache-php/bashrc.dist
@@ -65,3 +65,4 @@ alias c="clear"
 alias db="mysql -hdb -uroot -proot"
 
 export TERM=xterm
+umask 0007

--- a/docker/docker-ssh.sh
+++ b/docker/docker-ssh.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker exec -it -u www-data sf_web bash

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -48,7 +48,7 @@ docker exec -it $containerName chown -R www-data:www-data /var/www/.ssh
 docker exec -it $containerName composer selfupdate
 
 if [ $login = true ]; then
-	docker exec -it -u www-data $containerName bash
+	docker exec -it -u user $containerName bash
 	docker-compose stop
 fi
 

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -21,7 +21,7 @@ done
 
 containerName="sf_web"
 
-##Update Apache UID
+##grab host uid
 uid=$(id -u)
 if [ $uid -gt 100000 ]; then
 	uid=1000

--- a/docker/rsh-apache.sh
+++ b/docker/rsh-apache.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker exec -it -u www-data sf_web bash
+docker exec -it -u user sf_web bash

--- a/docker/rsh-apache.sh
+++ b/docker/rsh-apache.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker exec -it -u www-data sf_web bash

--- a/docker/rsh-mysql.sh
+++ b/docker/rsh-mysql.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker exec -it sf_db bash


### PR DESCRIPTION
**Package separation**

- Separated deb packages that are required during build vs. runtime.
In consequence please manage the build dependencies within the
BUILD_PKGS var. Packages required during runtime shall be placed in the RUNTIME_PKGS
var. Therefore build depencies can be removed once the build is completed.

- This allows to save 60MB Image Layerand therefore a smaller footprint.

**Permission Handling**

- So far the file permission conflict between the developer and the webserver was addressed using usermod. This was used to make the www-data=developer on host machine.
- It might make more sense, to add the developers userid to the group
www-data instead of overtaking the www-data user.
This change included.
ToDo: please test if sf3 is still working as intended / file interaction works as you wish.

**attaching to docker shells**

- renamed bash script to log into the running container to rsh-apache.sh
- added rsh-db.sh