### PR TITLE
xDebug for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Open the browser: [http://[docker-host]:8080](http://[docker-host]:8080)
 
 PHP7 is used.  
 
-Xdebug and Blackfire.io support are included by default.   
+Xdebug (only Linux and dlite for Mac)  and Blackfire.io support are included by default.   
 [» How to configure](Resources/doc/debug.md) 
 
 ### DB

--- a/Resources/doc/debug.md
+++ b/Resources/doc/debug.md
@@ -1,13 +1,11 @@
 # Debug
 
-On first startup the *docker-env.dist* file will be copied to the *docker-env* which will be used.  
-Do this manually and edit *docker-env* for your local settings, if you need to change values initally.  
+On every startup the *docker-env.dist* file will be copied to the *docker-env* which will be used.
+When copying, the remote\_host is set for xdebug.
 
 ## Xdebug
 
 Xdebug is activated. 
-- Change the php.ini settings for f.e. remote_host in the *docker-env* file according to your docker setup.
-  - `172.17.0.1` should work or your local IP
 - In PHPStorm settings:
   - Languages & Frameworks > PHP > Debug: 
     - Port 9000

--- a/docker/docker-env.dist
+++ b/docker/docker-env.dist
@@ -1,9 +1,4 @@
-#linux
-XDEBUG_CONFIG=remote_host=localhost remote_port=9000 xdebug.remote_mode=req xdebug.remote_handler=dbgp
-#dlite
-#XDEBUG_CONFIG=remote_host=local.docker remote_port=9000 xdebug.remote_mode=req xdebug.remote_handler=dbgp
-# the VMs IP that runs docker
-#XDEBUG_CONFIG=remote_host=192.168.2.165 remote_port=9000 xdebug.remote_mode=req xdebug.remote_handler=dbgp
+XDEBUG_CONFIG=remote_enable=1 remote_host=$HOST_IP remote_port=9000 remote_mode=req remote_handler=dbgp
 
 PHP_IDE_CONFIG=serverName=docker-sf3
 

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -29,7 +29,7 @@ fi
 
 case "$(uname -s)" in
     Linux*) host_ip="172.17.0.1";;
-    Darwin*) host_ip=$(dlite ip);;
+    Darwin*) host_ip=$(dlite status | grep dns_server | grep -oE "[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}");;
 esac
 
 sed "s/\$USER_ID/$uid/g" ./sf_web/Dockerfile.dist > ./sf_web/Dockerfile

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -33,7 +33,7 @@ case "$(uname -s)" in
 esac
 
 sed "s/\$USER_ID/$uid/g" ./sf_web/Dockerfile.dist > ./sf_web/Dockerfile
-sed "s/\$HOST_IP/$host_ip/g" ./sf_web/docker-env.dist > ./sf_web/docker-env
+sed "s/\$HOST_IP/$host_ip/g" ./docker-env.dist > ./docker-env
 
 
 ##build and launch containers

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -27,11 +27,14 @@ if [ $uid -gt 100000 ]; then
 	uid=1000
 fi
 
-sed "s/\$USER_ID/$uid/g" ./sf_web/Dockerfile.dist > ./sf_web/Dockerfile
+case "$(uname -s)" in
+    Linux*) host_ip="172.17.0.1";;
+    Darwin*) host_ip=$(dlite ip);;
+esac
 
-if [ ! -e ./docker-env ]; then
-    cp ./docker-env.dist ./docker-env
-fi
+sed "s/\$USER_ID/$uid/g" ./sf_web/Dockerfile.dist > ./sf_web/Dockerfile
+sed "s/\$HOST_IP/$host_ip/g" ./sf_web/docker-env.dist > ./sf_web/docker-env
+
 
 ##build and launch containers
 docker-compose build


### PR DESCRIPTION
Enable xDebug for CLI in Linux und Dlite Docker containers.